### PR TITLE
Hotfix Medius MAPS subserver

### DIFF
--- a/SpecializedServers/Horizon/SERVER/Medius/MAPS.cs
+++ b/SpecializedServers/Horizon/SERVER/Medius/MAPS.cs
@@ -91,7 +91,7 @@ namespace Horizon.SERVER.Medius
                             LoggerAccessor.LogInfo($"[MAPS] - Client Connected {clientChannel.RemoteAddress}!");
                         else
                         {
-                            LoggerAccessor.LogInfo($"[MAS] - Client Connected {clientChannel.RemoteAddress} with new ClientObject!");
+                            LoggerAccessor.LogInfo($"[MAPS] - Client Connected {clientChannel.RemoteAddress} with new ClientObject!");
 
                             data.ClientObject = new(scertClient.MediusVersion ?? 0)
                             {

--- a/SpecializedServers/Horizon/SERVER/MediusClass.cs
+++ b/SpecializedServers/Horizon/SERVER/MediusClass.cs
@@ -198,7 +198,7 @@ namespace Horizon.SERVER
                     if (Settings.EnableMAPS == true)
                     {
                         LoggerAccessor.LogInfo($"MAPS Version: {Settings.MAPSVersion}");
-                        LoggerAccessor.LogInfo($"Enabling MAPS on Server IP = {SERVER_IP} TCP Port = {AuthenticationServer.TCPPort} UDP Port = {AuthenticationServer.UDPPort}.");
+                        LoggerAccessor.LogInfo($"Enabling MAPS on Server IP = {SERVER_IP} TCP Port = {ProfileServer.TCPPort} UDP Port = {ProfileServer.UDPPort}.");
 
                         ProfileServer.Start();
                         LoggerAccessor.LogInfo("Medius Profile Server Intialized and Now Accepting Clients");


### PR DESCRIPTION
- Allows MAPS to reserve a clientobject prior to auth on MAS in MAG/Socom 4.
- Adds support for the EndianTools library, these 2 games bitshift a LOT.
- Fixes the server port if the MediusServerVersionOverride was enabled.