### PR TITLE
Medius MatchMaking Service Improvements

### DIFF
--- a/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusAssignedGameToJoinMessage.cs
+++ b/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusAssignedGameToJoinMessage.cs
@@ -1,8 +1,8 @@
-using System.IO;
 using Horizon.RT.Common;
 using Horizon.LIBRARY.Common.Stream;
+using System;
 
-namespace Horizon.RT.Models.Lobby
+namespace Horizon.RT.Models
 {
     [MediusMessage(NetMessageClass.MessageClassLobbyExt, MediusLobbyExtMessageIds.AssignedGameToJoinMessage)]
     public class MediusAssignedGameToJoinMessage : BaseLobbyExtMessage
@@ -12,14 +12,10 @@ namespace Horizon.RT.Models.Lobby
         public bool IsSuccess => StatusCode >= 0;
 
         public byte[] AssignedGameMessageRequestData = new byte[Constants.REQUESTDATA_MAXLEN];
-        public int AssignedGameMessageID;
+        public MessageId AssignedGameMessageID;
         public MediusAssignedGameType AssignedGameType;
         public MediusCallbackStatus StatusCode;
         public int SystemSpecificStatusCode;
-
-        public MediusAssignedGameToJoin mediusAssignedGameToJoin;
-
-        public int Unk1;
         public uint GameWorldID;
         public uint TeamID;
         public int PlayerCount;
@@ -44,161 +40,119 @@ namespace Horizon.RT.Models.Lobby
         public MGCL_GAME_HOST_TYPE GameHostType;
         public NetAddressList AddressList;
         public uint AppDataSize;
-        public string AppData;
+        public byte[] AppData;
 
         public override void Deserialize(MessageReader reader)
         {
+            // 
             base.Deserialize(reader);
 
+            //
             AssignedGameMessageRequestData = reader.ReadBytes(Constants.REQUESTDATA_MAXLEN);
-            AssignedGameMessageID = reader.ReadInt32();
+            AssignedGameMessageID = reader.Read<MessageId>();
             AssignedGameType = reader.Read<MediusAssignedGameType>();
             StatusCode = reader.Read<MediusCallbackStatus>();
             SystemSpecificStatusCode = reader.ReadInt32();
-
-            if (StatusCode == MediusCallbackStatus.MediusJoinAssignedGame)
-            {
-                reader.ReadBytes(4);
-                GameWorldID = reader.ReadUInt32();
-                //reader.ReadBytes(2);
-                TeamID = reader.ReadUInt32();
-                PlayerCount = reader.ReadInt32();
-                GameName = reader.ReadString(Constants.GAMENAME_MAXLEN);
-                GameStats = reader.ReadBytes(Constants.GAMESTATS_MAXLEN);
-                MinPlayers = reader.ReadInt32();
-                MaxPlayers = reader.ReadInt32();
-                GameLevel = reader.ReadInt32();
-                PlayerSkillLevel = reader.ReadInt32();
-                RulesSet = reader.ReadInt32();
-                GenericField1 = reader.ReadInt32();
-                GenericField2 = reader.ReadInt32();
-                GenericField3 = reader.ReadInt32();
-                GenericField4 = reader.ReadInt32();
-                GenericField5 = reader.ReadInt32();
-                GenericField6 = reader.ReadInt32();
-                GenericField7 = reader.ReadInt32();
-                GenericField8 = reader.ReadInt32();
-                WorldStatus = reader.Read<MediusWorldStatus>();
-                JoinType = reader.Read<MediusJoinType>();
-                GamePassword = reader.ReadString(Constants.GAMEPASSWORD_MAXLEN);
-                GameHostType = reader.Read<MGCL_GAME_HOST_TYPE>();
-                AddressList = reader.Read<NetAddressList>();
-                AppDataSize = reader.ReadUInt32();
-                AppData = reader.ReadString((int)AppDataSize);
-            }
+            GameWorldID = reader.ReadUInt32();
+            TeamID = reader.ReadUInt32();
+            PlayerCount = reader.ReadInt32();
+            GameName = reader.ReadString(Constants.GAMENAME_MAXLEN);
+            GameStats = reader.ReadBytes(Constants.GAMESTATS_MAXLEN);
+            MinPlayers = reader.ReadInt32();
+            MaxPlayers = reader.ReadInt32();
+            GameLevel = reader.ReadInt32();
+            PlayerSkillLevel = reader.ReadInt32();
+            RulesSet = reader.ReadInt32();
+            GenericField1 = reader.ReadInt32();
+            GenericField2 = reader.ReadInt32();
+            GenericField3 = reader.ReadInt32();
+            GenericField4 = reader.ReadInt32();
+            GenericField5 = reader.ReadInt32();
+            GenericField6 = reader.ReadInt32();
+            GenericField7 = reader.ReadInt32();
+            GenericField8 = reader.ReadInt32();
+            WorldStatus = reader.Read<MediusWorldStatus>();
+            JoinType = reader.Read<MediusJoinType>();
+            GamePassword = reader.ReadString(Constants.GAMEPASSWORD_MAXLEN);
+            GameHostType = reader.Read<MGCL_GAME_HOST_TYPE>();
+            AddressList = reader.Read<NetAddressList>();
+            AppDataSize = reader.ReadUInt32();
+            AppData = reader.ReadBytes((int)AppDataSize);
         }
 
         public override void Serialize(MessageWriter writer)
         {
+            // 
             base.Serialize(writer);
 
+            //
             writer.Write(AssignedGameMessageRequestData, Constants.REQUESTDATA_MAXLEN);
             writer.Write(AssignedGameMessageID);
             writer.Write(AssignedGameType);
             writer.Write(StatusCode);
             writer.Write(SystemSpecificStatusCode);
+            writer.Write(GameWorldID);
+            writer.Write(TeamID);
+            writer.Write(PlayerCount);
+            writer.Write(GameName, Constants.GAMENAME_MAXLEN);
+            writer.Write(GameStats, Constants.GAMESTATS_MAXLEN);
+            writer.Write(MinPlayers);
+            writer.Write(MaxPlayers);
+            writer.Write(GameLevel);
+            writer.Write(PlayerSkillLevel);
+            writer.Write(RulesSet);
+            writer.Write(GenericField1);
+            writer.Write(GenericField2);
+            writer.Write(GenericField3);
+            writer.Write(GenericField4);
+            writer.Write(GenericField5);
+            writer.Write(GenericField6);
+            writer.Write(GenericField7);
+            writer.Write(GenericField8);
+            writer.Write(WorldStatus);
+            writer.Write(JoinType);
+            writer.Write(GamePassword, Constants.GAMEPASSWORD_MAXLEN);
+            writer.Write(GameHostType);
+            writer.Write(AddressList);
+            writer.Write(AppDataSize);
+            writer.Write(AppData);
 
-            if (StatusCode == MediusCallbackStatus.MediusJoinAssignedGame)
-            {
-                //writer.Write(new byte[4] /*{ 0, 0, 0, 0 }*/);
 
-                writer.Write(Unk1);
-                writer.Write(GameWorldID);
-                writer.Write(TeamID);
-                writer.Write(PlayerCount);
-                writer.Write(GameName, Constants.GAMENAME_MAXLEN);
-                writer.Write(GameStats, Constants.GAMESTATS_MAXLEN);
-                writer.Write(MinPlayers);
-                writer.Write(MaxPlayers);
-                writer.Write(GameLevel);
-                writer.Write(PlayerSkillLevel);
-                writer.Write(RulesSet);
-                writer.Write(GenericField1);
-                writer.Write(GenericField2);
-                writer.Write(GenericField3);
-                writer.Write(GenericField4);
-                writer.Write(GenericField5);
-                writer.Write(GenericField6);
-                writer.Write(GenericField7);
-                writer.Write(GenericField8);
-                writer.Write(WorldStatus);
-                writer.Write(JoinType);
-                writer.Write(GamePassword, Constants.GAMEPASSWORD_MAXLEN);
-                writer.Write(GameHostType);
-                writer.Write(AddressList);
-                writer.Write(AppDataSize);
-                writer.Write(AppData, (int)AppDataSize);
-            }
         }
 
         public override string ToString()
         {
-            if (StatusCode == MediusCallbackStatus.MediusJoinAssignedGame)
-                return base.ToString() + " " +
-                $"AssignedGameMessageRequestData: {string.Join(string.Empty, AssignedGameMessageRequestData)} " +
-                $"AssignedGameMessageID:{AssignedGameMessageID} " +
-                $"AssignedGameType:{AssignedGameType} " +
-                $"StatusCode:{StatusCode} " +
-                $"SystemSpecificStatusCode:{SystemSpecificStatusCode} " +
+            return base.ToString() + " " +
+                $"AssignedGameMessageRequestData: {string.Join("", AssignedGameMessageRequestData)} " +
+                $"AssignedGameMessageID: {AssignedGameMessageID} " +
+                $"AssignedGameType: {AssignedGameType} " +
+                $"StatusCode: {StatusCode} " +
+                $"SystemSpecificStatusCode: {SystemSpecificStatusCode} " +
                 $"GameWorldID: {GameWorldID} " +
                 $"TeamID: {TeamID} " +
-                $"PlayerCount:{PlayerCount} " +
-                $"GameName:{GameName} " +
-                $"GameStats:{System.BitConverter.ToString(GameStats)} " +
-                $"MinPlayers:{MinPlayers} " +
-                $"MaxPlayers:{MaxPlayers} " +
-                $"GameLevel:{GameLevel} " +
-                $"PlayerSkillLevel:{PlayerSkillLevel} " +
-                $"RulesSet:{RulesSet} " +
-                $"GenericField1:{GenericField1:X8} " +
-                $"GenericField2:{GenericField2:X8} " +
-                $"GenericField3:{GenericField3:X8} " +
-                $"GenericField4:{GenericField4:X8} " +
-                $"GenericField5:{GenericField5:X8} " +
-                $"GenericField6:{GenericField6:X8} " +
-                $"GenericField7:{GenericField7:X8} " +
-                $"GenericField8:{GenericField8:X8} " +
-                $"WorldStatus:{WorldStatus} " +
+                $"PlayerCount: {PlayerCount} " +
+                $"GameName: {GameName} " +
+                $"GameStats: {BitConverter.ToString(GameStats)} " +
+                $"MinPlayers: {MinPlayers} " +
+                $"MaxPlayers: {MaxPlayers} " +
+                $"GameLevel: {GameLevel} " +
+                $"PlayerSkillLevel: {PlayerSkillLevel} " +
+                $"RulesSet: {RulesSet} " +
+                $"GenericField1: {GenericField1:X8} " +
+                $"GenericField2: {GenericField2:X8} " +
+                $"GenericField3: {GenericField3:X8} " +
+                $"GenericField4: {GenericField4:X8} " +
+                $"GenericField5: {GenericField5:X8} " +
+                $"GenericField6: {GenericField6:X8} " +
+                $"GenericField7: {GenericField7:X8} " +
+                $"GenericField8: {GenericField8:X8} " +
+                $"WorldStatus: {WorldStatus} " +
                 $"JoinType: {JoinType} " +
                 $"GamePassword: {GamePassword} " +
-                $"GameHostType:{GameHostType} " +
+                $"GameHostType: {GameHostType} " +
                 $"NetAddressList: {AddressList} " +
                 $"AppDataSize: {AppDataSize} " +
-                $"AppData: {string.Join(string.Empty, AppData)}";
-            else
-            {
-                return base.ToString() + " " +
-                $"AssignedGameMessageRequestData: {string.Join(string.Empty, AssignedGameMessageRequestData)} " +
-                $"AssignedGameMessageID:{AssignedGameMessageID} " +
-                $"AssignedGameType:{AssignedGameType} " +
-                $"StatusCode:{StatusCode} " +
-                $"SystemSpecificStatusCode:{SystemSpecificStatusCode} " +
-                $"GameWorldID: {GameWorldID} " +
-                $"TeamID: {TeamID} " +
-                $"PlayerCount:{PlayerCount} " +
-                $"GameName:{GameName} " +
-                $"GameStats: {System.BitConverter.ToString(GameStats)} " +
-                $"MinPlayers:{MinPlayers} " +
-                $"MaxPlayers:{MaxPlayers} " +
-                $"GameLevel:{GameLevel} " +
-                $"PlayerSkillLevel:{PlayerSkillLevel} " +
-                $"RulesSet:{RulesSet} " +
-                $"GenericField1:{GenericField1:X8} " +
-                $"GenericField2:{GenericField2:X8} " +
-                $"GenericField3:{GenericField3:X8} " +
-                $"GenericField4:{GenericField4:X8} " +
-                $"GenericField5:{GenericField5:X8} " +
-                $"GenericField6:{GenericField6:X8} " +
-                $"GenericField7:{GenericField7:X8} " +
-                $"GenericField8:{GenericField8:X8} " +
-                $"WorldStatus:{WorldStatus} " +
-                $"JoinType: {JoinType} " +
-                $"GamePassword: {GamePassword} " +
-                $"GameHostType:{GameHostType} " +
-                $"NetAddressList: {AddressList} " +
-                $"AppDataSize: {AppDataSize} " +
-                $"AppData: {string.Join(string.Empty, AppData)}";
-            }
+                $"AppData: {string.Join("", AppData)}";
         }
     }
 }

--- a/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchCreateGameRequest.cs
+++ b/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchCreateGameRequest.cs
@@ -1,6 +1,5 @@
-using System.IO;
-using Horizon.RT.Common;
 using Horizon.LIBRARY.Common.Stream;
+using Horizon.RT.Common;
 
 namespace Horizon.RT.Models
 {
@@ -37,17 +36,14 @@ namespace Horizon.RT.Models
         public uint GroupMemberListSize;
         public uint ApplicationDataSize;
         public byte[] GroupMemberAccountIDList;
-        public string ApplicationData;
+        public byte[] ApplicationData;
 
         public override void Deserialize(MessageReader reader)
         {
             base.Deserialize(reader);
 
             MessageID = reader.Read<MessageId>();
-
             SessionKey = reader.ReadString(Constants.SESSIONKEY_MAXLEN);
-            //reader.ReadBytes(2);
-
             SupersetID = reader.ReadInt32();
             ApplicationID = reader.ReadInt32();
             MinPlayers = reader.ReadInt32();
@@ -71,12 +67,11 @@ namespace Horizon.RT.Models
             MatchOptions = reader.Read<MediusMatchOptions>();
             ServerSessionKey = reader.ReadString(Constants.SESSIONKEY_MAXLEN);
             RequestData = reader.ReadBytes(Constants.REQUESTDATA_MAXLEN);
-            //reader.ReadBytes(3);
-
             GroupMemberListSize = reader.ReadUInt32();
             ApplicationDataSize = reader.ReadUInt32();
             GroupMemberAccountIDList = reader.ReadBytes((int)GroupMemberListSize);
-            ApplicationData = reader.ReadString((int)GroupMemberListSize);
+            ApplicationData = reader.ReadBytes((int)GroupMemberListSize);
+
         }
 
         public override void Serialize(MessageWriter writer)
@@ -84,10 +79,7 @@ namespace Horizon.RT.Models
             base.Serialize(writer);
 
             writer.Write(MessageID ?? MessageId.Empty);
-
             writer.Write(SessionKey, Constants.SESSIONKEY_MAXLEN);
-            //writer.Write(new byte[2]);
-
             writer.Write(SupersetID);
             writer.Write(ApplicationID);
             writer.Write(MinPlayers);
@@ -111,12 +103,10 @@ namespace Horizon.RT.Models
             writer.Write(MatchOptions);
             writer.Write(ServerSessionKey, Constants.SESSIONKEY_MAXLEN);
             writer.Write(RequestData);
-            //writer.Write(new byte[3]);
-
             writer.Write(GroupMemberListSize);
             writer.Write(ApplicationDataSize);
             writer.Write(GroupMemberAccountIDList);
-            writer.Write(ApplicationData, (int)ApplicationDataSize);
+            writer.Write(ApplicationData);
         }
 
         public override string ToString()
@@ -146,10 +136,10 @@ namespace Horizon.RT.Models
                 $"WorldAttributesType: {WorldAttributesType} " +
                 $"MatchOptions: {MatchOptions} " +
                 $"ServerSessionKey: {ServerSessionKey} " +
-                $"RequestData: {RequestData} " +
+                $"RequestData: {string.Join(string.Empty, RequestData)} " +
                 $"GroupMemberListSize: {GroupMemberListSize} " +
                 $"ApplicationDataSize: {ApplicationDataSize} " +
-                $"GroupMemberAccountIDList: {GroupMemberAccountIDList} " +
+                $"GroupMemberAccountIDList: {string.Join(string.Empty, GroupMemberAccountIDList)} " +
                 $"ApplicationData: {string.Join(string.Empty, ApplicationData)}";
         }
     }

--- a/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchFindGameRequest.cs
+++ b/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchFindGameRequest.cs
@@ -69,25 +69,18 @@ namespace Horizon.RT.Models
         /// <summary>
         /// GroupMemberAccountIDList
         /// </summary>
-        public char[] GroupMemberAccountIDList;
+        public byte[] GroupMemberAccountIDList;
         /// <summary>
         /// ApplicationData
         /// </summary>
-        public char[] ApplicationData;
+        public byte[] ApplicationData;
 
         public override void Deserialize(MessageReader reader)
         {
-            // 
             base.Deserialize(reader);
 
-            //
             MessageID = reader.Read<MessageId>();
-
-            // 
             SessionKey = reader.ReadString(Constants.SESSIONKEY_MAXLEN);
-            //reader.ReadBytes(2);
-            
-            //
             SupersetID = reader.ReadUInt32();
             MediusWorldID = reader.ReadInt32();
             PlayerJoinType = reader.Read<MediusJoinType>();
@@ -97,26 +90,18 @@ namespace Horizon.RT.Models
             MatchOptions = reader.Read<MediusMatchOptions>();
             ServerSessionKey = reader.ReadString(Constants.SESSIONKEY_MAXLEN);
             RequestData = reader.ReadString(Constants.REQUESTDATA_MAXLEN);
-            //reader.ReadBytes(3);
-
-            //
             GroupMemberListSize = reader.ReadUInt32();
             ApplicationDataSize = reader.ReadUInt32();
-            GroupMemberAccountIDList = reader.ReadChars((int)GroupMemberListSize);
-            ApplicationData = reader.ReadChars((int)ApplicationDataSize);
+            GroupMemberAccountIDList = reader.ReadBytes((int)GroupMemberListSize);
+            ApplicationData = reader.ReadBytes((int)ApplicationDataSize);
         }
 
         public override void Serialize(MessageWriter writer)
-        {
-            // 
+        {            
             base.Serialize(writer);
 
-            //
             writer.Write(MessageID ?? MessageId.Empty);
             writer.Write(SessionKey, Constants.SESSIONKEY_MAXLEN);
-            //writer.Write(new byte[2]);
-
-            //
             writer.Write(SupersetID);
             writer.Write(MediusWorldID);
             writer.Write(PlayerJoinType);
@@ -126,9 +111,6 @@ namespace Horizon.RT.Models
             writer.Write(MatchOptions);
             writer.Write(ServerSessionKey, Constants.SESSIONKEY_MAXLEN);
             writer.Write(RequestData, Constants.REQUESTDATA_MAXLEN);
-            //writer.Write(new byte[3]);
-
-            //
             writer.Write(GroupMemberListSize);
             writer.Write(ApplicationDataSize);
             writer.Write(GroupMemberAccountIDList);
@@ -152,8 +134,8 @@ namespace Horizon.RT.Models
                 $"RequestData: {RequestData} " +
                 $"GroupMemberListSize: {GroupMemberListSize} " +
                 $"ApplicationDataSize: {ApplicationDataSize} " +
-                $"GroupMemberAccountIDList: {GroupMemberAccountIDList} " +
-                $"ApplicationData: {ApplicationData} ";
+                $"GroupMemberAccountIDList: {string.Join(string.Empty, GroupMemberAccountIDList)} " +
+                $"ApplicationData: {string.Join(string.Empty, ApplicationData)} ";
         }
     }
 }

--- a/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchGetSupersetListRequest.cs
+++ b/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchGetSupersetListRequest.cs
@@ -24,25 +24,17 @@ namespace Horizon.RT.Models
 
         public override void Deserialize(MessageReader reader)
         {
-            // 
             base.Deserialize(reader);
 
-            //
             MessageID = reader.Read<MessageId>();
-
-            // 
             SessionKey = reader.ReadString(Constants.SESSIONKEY_MAXLEN);
         }
 
         public override void Serialize(MessageWriter writer)
         {
-            // 
             base.Serialize(writer);
 
-            //
             writer.Write(MessageID ?? MessageId.Empty);
-
-            // 
             writer.Write(SessionKey, Constants.SESSIONKEY_MAXLEN);
         }
 

--- a/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchSetGameStateRequest.cs
+++ b/BackendServices/AuxiliaryServices/HorizonService/RT.Models/Lobby/MediusMatchSetGameStateRequest.cs
@@ -1,11 +1,12 @@
-using System.IO;
+using Horizon.LIBRARY.Common.Stream;
+using Horizon.RT.Common;
+
 namespace Horizon.RT.Models
 {
-    /*
-    [MediusMessage(NetMessageClass.MessageClassLobbyExt, MediusLobbyExtMessageIds.MatchSetGameStateRequest)] // Set GameState
+    [MediusMessage(NetMessageClass.MessageClassLobbyExt, MediusLobbyExtMessageIds.MatchSetGameStateRequest)]
     public class MediusMatchSetGameStateRequest : BaseLobbyExtMessage, IMediusRequest
     {
-        public override byte PacketType => (byte)MediusLobbyExtMessageIds.MatchSetGameStateRequest; // Set GameState
+        public override byte PacketType => (byte)MediusLobbyExtMessageIds.MatchSetGameStateRequest;
 
         public MessageId MessageID { get; set; }
         public string SessionKey; // SESSIONKEY_MAXLEN
@@ -13,26 +14,18 @@ namespace Horizon.RT.Models
 
         public override void Deserialize(MessageReader reader)
         {
-            // 
             base.Deserialize(reader);
 
-            //
             MessageID = reader.Read<MessageId>();
-
-            // 
             SessionKey = reader.ReadString(Constants.SESSIONKEY_MAXLEN);
             MatchGameState = reader.Read<MediusMatchGameState>();
         }
 
         public override void Serialize(MessageWriter writer)
         {
-            // 
             base.Serialize(writer);
 
-            //
             writer.Write(MessageID ?? MessageId.Empty);
-
-            // 
             writer.Write(SessionKey, Constants.SESSIONKEY_MAXLEN);
             writer.Write(MatchGameState);
         }
@@ -45,5 +38,4 @@ namespace Horizon.RT.Models
                 $"GameState: {MatchGameState}";
         }
     }
-    */
 }

--- a/SpecializedServers/Horizon/MUM/Models/Game.cs
+++ b/SpecializedServers/Horizon/MUM/Models/Game.cs
@@ -57,7 +57,7 @@ namespace Horizon.MUM.Models
         public uint GroupMemberListSize;
         public byte[]? GroupMemberList;
         public uint AppDataSize;
-        public string? AppData;
+        public byte[]? AppData;
 
         public MediusWorldStatus WorldStatus => _worldStatus;
         public MediusWorldAttributesType Attributes;

--- a/SpecializedServers/Horizon/SERVER/Medius/MLS.cs
+++ b/SpecializedServers/Horizon/SERVER/Medius/MLS.cs
@@ -1327,7 +1327,7 @@ namespace Horizon.SERVER.Medius
                         */
                         break;
                     }
-                /*
+                
             case MediusMatchSetGameStateRequest mediusMatchSetGameStateRequest:
                 {
                         if (data.ClientObject == null)
@@ -1356,7 +1356,7 @@ namespace Horizon.SERVER.Medius
 
                     break;
                 }
-                */
+                
                 #endregion
 
                 #region Version Server
@@ -10624,20 +10624,21 @@ namespace Horizon.SERVER.Medius
 
         public void AssignGameToJoin(ClientObject clientObject, MediusMatchFindGameRequest matchFindGameRequest)
         {
-            //We Sleep for a bit so we return another packet for the matchmaked game we may have found!
-
             uint gameCount = MediusClass.Manager.GetGameCount(clientObject.ApplicationId);
+
+
+            //If no games exist, we return no result
             if (gameCount == 0)
             {
+                // Tell the client their new assigned game
                 clientObject.Queue(new MediusAssignedGameToJoinMessage()
                 {
                     AssignedGameMessageRequestData = new byte[Constants.REQUESTDATA_MAXLEN],
-                    AssignedGameMessageID = 0,
+                    AssignedGameMessageID = matchFindGameRequest.MessageID,
                     AssignedGameType = MediusAssignedGameType.AssignedGameTypeMMS,
                     StatusCode = MediusCallbackStatus.MediusNoResult,
                     SystemSpecificStatusCode = 0,
-
-                    GameWorldID = 0, //TEMP
+                    GameWorldID = 0,
                     TeamID = 0,
                     PlayerCount = 0,
                     GameName = string.Empty,
@@ -10667,182 +10668,113 @@ namespace Horizon.SERVER.Medius
                          }
                     },
                     AppDataSize = 0,
-                    AppData = string.Empty
-                    /*
-                        mediusAssignedGameToJoin = new MediusAssignedGameToJoin()
-                        {
-
-                            GameWorldID = 0, //TEMP
-                            TeamID = 0,
-                            PlayerCount = 0,
-                            GameName = "",
-                            GameStats = new byte[Constants.GAMESTATS_MAXLEN],
-                            MinPlayers = 0,
-                            MaxPlayers = 0,
-                            GameLevel = 0,
-                            PlayerSkillLevel = 0,
-                            GenericField1 = 0,
-                            GenericField2 = 0,
-                            GenericField3 = 0,
-                            GenericField4 = 0,
-                            GenericField5 = 0,
-                            GenericField6 = 0,
-                            GenericField7 = 0,
-                            GenericField8 = 0,
-                            WorldStatus = MediusWorldStatus.WorldInactive,
-                            JoinType = MediusJoinType.MediusJoinAsPlayer,
-                            GamePassword = "",
-                            GameHostType = MediusGameHostType.MediusGameHostClientServer,
-                            AddressList = new NetAddressList()
-                            {
-                                AddressList = new NetAddress[Constants.NET_ADDRESS_LIST_COUNT]
-                            {
-                                new NetAddress() { AddressType = NetAddressType.NetAddressNone },
-                                new NetAddress() { AddressType = NetAddressType.NetAddressNone }
-                             }
-                            },
-                            AppDataSize = 0,
-                            AppData = new byte[0]
-                        }
-                        */
-                        });
+                    AppData = new byte[0],
+                });
             }
             else
             {
-                if (matchFindGameRequest.MediusWorldID != 0)
-                {
-                    var gameInfo = MediusClass.Manager.GetGameByGameId(matchFindGameRequest.MediusWorldID);
 
-                    var dmeServer = gameInfo.DMEServer;
+                ClientObject dmeServer;
+                //Quick Match 
+                if (matchFindGameRequest.MediusWorldID == 0)
+                {
+                    var gameInfoRandomPick = MediusClass.Manager.GetGameListAppId(clientObject.ApplicationId, 1, 10).FirstOrDefault();
+                    dmeServer = gameInfoRandomPick.DMEServer;
 
                     // Tell the client their new assigned game
                     clientObject.Queue(new MediusAssignedGameToJoinMessage()
                     {
-                        AssignedGameMessageRequestData = gameInfo.RequestData,
-                        AssignedGameMessageID = 0,
+                        AssignedGameMessageRequestData = gameInfoRandomPick.RequestData,
+                        AssignedGameMessageID = matchFindGameRequest.MessageID,
                         AssignedGameType = MediusAssignedGameType.AssignedGameTypeMMS,
                         StatusCode = MediusCallbackStatus.MediusJoinAssignedGame,
                         SystemSpecificStatusCode = 0,
-                        /*
-                        Unk1 = 0,
-                        GameWorldID = (uint)gameInfo.Id, //TEMP
-                        TeamID = 1,
-                        PlayerCount = 0,
-                        GameName = string.Empty,
-                        GameStats = new byte[Constants.GAMESTATS_MAXLEN],
-                        MinPlayers = 0,
-                        MaxPlayers = 0,
-                        GameLevel = 0,
-                        PlayerSkillLevel = 0,
-                        GenericField1 = 0,
-                        GenericField2 = 0,
-                        GenericField3 = 0,
-                        GenericField4 = 0,
-                        GenericField5 = 0,
-                        GenericField6 = 0,
-                        GenericField7 = 0,
-                        GenericField8 = 0,
-                        WorldStatus = gameInfo.WorldStatus,
-                        JoinType = MediusJoinType.MediusJoinAsPlayer,
-                        GamePassword = string.Empty,
-                        GameHostType = gameInfo.GameHostType,
-                        AddressList = new NetAddressList()
-                        {
-                            AddressList = new NetAddress[Constants.NET_ADDRESS_LIST_COUNT]
-                            {
-                                //new NetAddress() { Address = dmeServer.IP.MapToIPv4().ToString(), Port = dmeServer.Port, AddressType = NetAddressType.NetAddressTypeExternal},
-                                new NetAddress() { AddressType = NetAddressType.NetAddressNone },
-                                new NetAddress() { AddressType = NetAddressType.NetAddressNone } 
-                                //new NetAddress() { Address = MediusClass.Settings.NATIp, Port = MediusClass.Settings.NATPort, AddressType = NetAddressType.NetAddressTypeNATService },
-                            }
-                        },
-                        AppDataSize = 0,
-                        AppData = new char[0]
-                        */
-
-                        GameWorldID = 0,//(uint)gameInfo.Id, //TEMP
+                        GameWorldID = (uint)gameInfoRandomPick.MediusWorldId,
                         TeamID = 0,
-                        PlayerCount = gameInfo.PlayerCount,
-                        GameName = gameInfo.GameName,
-                        GameStats = gameInfo.GameStats,
-                        MinPlayers = gameInfo.MinPlayers,
-                        MaxPlayers = gameInfo.MaxPlayers,
-                        GameLevel = gameInfo.GameLevel,
-                        PlayerSkillLevel = gameInfo.PlayerSkillLevel,
-                        GenericField1 = gameInfo.GenericField1,
-                        GenericField2 = gameInfo.GenericField2,
-                        GenericField3 = gameInfo.GenericField3,
-                        GenericField4 = gameInfo.GenericField4,
-                        GenericField5 = gameInfo.GenericField5,
-                        GenericField6 = gameInfo.GenericField6,
-                        GenericField7 = gameInfo.GenericField7,
-                        GenericField8 = gameInfo.GenericField8,
-                        WorldStatus = gameInfo.WorldStatus,
+                        PlayerCount = gameInfoRandomPick.PlayerCount,
+                        GameName = gameInfoRandomPick.GameName,
+                        GameStats = gameInfoRandomPick.GameStats,
+                        MinPlayers = gameInfoRandomPick.MinPlayers,
+                        MaxPlayers = gameInfoRandomPick.MaxPlayers,
+                        GameLevel = gameInfoRandomPick.GameLevel,
+                        PlayerSkillLevel = gameInfoRandomPick.PlayerSkillLevel,
+                        GenericField1 = gameInfoRandomPick.GenericField1,
+                        GenericField2 = gameInfoRandomPick.GenericField2,
+                        GenericField3 = gameInfoRandomPick.GenericField3,
+                        GenericField4 = gameInfoRandomPick.GenericField4,
+                        GenericField5 = gameInfoRandomPick.GenericField5,
+                        GenericField6 = gameInfoRandomPick.GenericField6,
+                        GenericField7 = gameInfoRandomPick.GenericField7,
+                        GenericField8 = gameInfoRandomPick.GenericField8,
+                        WorldStatus = gameInfoRandomPick.WorldStatus,
                         JoinType = MediusJoinType.MediusJoinAsPlayer,
-                        GamePassword = gameInfo.GamePassword,
-                        GameHostType = gameInfo.GameHostType,
+                        GamePassword = gameInfoRandomPick.GamePassword,
+                        GameHostType = gameInfoRandomPick.GameHostType,
                         AddressList = new NetAddressList()
                         {
                             AddressList = new NetAddress[Constants.NET_ADDRESS_LIST_COUNT]
                                 {
-                                    new NetAddress() { Address = dmeServer.IP.MapToIPv4().ToString(), Port = dmeServer.Port, AddressType = NetAddressType.NetAddressTypeExternal},
-                                    new NetAddress() { AddressType = NetAddressType.NetAddressNone }
+                                        new NetAddress() { Address = dmeServer.IP.MapToIPv4().ToString(), Port = dmeServer.Port, AddressType = NetAddressType.NetAddressTypeExternal},
+                                        new NetAddress() { AddressType = NetAddressType.NetAddressNone }
                                 }
                         },
-                        AppDataSize = gameInfo.AppDataSize,
-                        AppData = gameInfo.AppData
+                        AppDataSize = gameInfoRandomPick.AppDataSize,
+                        AppData = gameInfoRandomPick.AppData
+
                     });
                 }
+                //Game List
                 else
                 {
-                    var gameMatchFound = MediusClass.Manager.GetGameListAppId(clientObject.ApplicationId, 1, 100).First();
-
-                    var dmeServer = gameMatchFound.DMEServer;
+                    var gameInfoByGameWorldID = MediusClass.Manager.GetGameByGameId((int)matchFindGameRequest.MediusWorldID);
+                    dmeServer = gameInfoByGameWorldID.DMEServer;
 
                     // Tell the client their new assigned game
                     clientObject.Queue(new MediusAssignedGameToJoinMessage()
                     {
-                        AssignedGameMessageRequestData = gameMatchFound.RequestData,
-                        AssignedGameMessageID = 2,
+                        AssignedGameMessageRequestData = gameInfoByGameWorldID.RequestData,
+                        AssignedGameMessageID = matchFindGameRequest.MessageID,
                         AssignedGameType = MediusAssignedGameType.AssignedGameTypeMMS,
                         StatusCode = MediusCallbackStatus.MediusJoinAssignedGame,
                         SystemSpecificStatusCode = 0,
-
-                        GameWorldID = (ushort)gameMatchFound.MediusWorldId, // TEMP
-
+                        GameWorldID = (uint)gameInfoByGameWorldID.MediusWorldId,
                         TeamID = 0,
-                        PlayerCount = gameMatchFound.PlayerCount,
-                        GameName = gameMatchFound.GameName,
-                        GameStats = gameMatchFound.GameStats,
-                        MinPlayers = gameMatchFound.MinPlayers,
-                        MaxPlayers = gameMatchFound.MaxPlayers,
-                        GameLevel = gameMatchFound.GameLevel,
-                        PlayerSkillLevel = gameMatchFound.PlayerSkillLevel,
-                        GenericField1 = gameMatchFound.GenericField1,
-                        GenericField2 = gameMatchFound.GenericField2,
-                        GenericField3 = gameMatchFound.GenericField3,
-                        GenericField4 = gameMatchFound.GenericField4,
-                        GenericField5 = gameMatchFound.GenericField5,
-                        GenericField6 = gameMatchFound.GenericField6,
-                        GenericField7 = gameMatchFound.GenericField7,
-                        GenericField8 = gameMatchFound.GenericField8,
-                        WorldStatus = gameMatchFound.WorldStatus,
+                        PlayerCount = gameInfoByGameWorldID.PlayerCount,
+                        GameName = gameInfoByGameWorldID.GameName,
+                        GameStats = gameInfoByGameWorldID.GameStats,
+                        MinPlayers = gameInfoByGameWorldID.MinPlayers,
+                        MaxPlayers = gameInfoByGameWorldID.MaxPlayers,
+                        GameLevel = gameInfoByGameWorldID.GameLevel,
+                        PlayerSkillLevel = gameInfoByGameWorldID.PlayerSkillLevel,
+                        GenericField1 = gameInfoByGameWorldID.GenericField1,
+                        GenericField2 = gameInfoByGameWorldID.GenericField2,
+                        GenericField3 = gameInfoByGameWorldID.GenericField3,
+                        GenericField4 = gameInfoByGameWorldID.GenericField4,
+                        GenericField5 = gameInfoByGameWorldID.GenericField5,
+                        GenericField6 = gameInfoByGameWorldID.GenericField6,
+                        GenericField7 = gameInfoByGameWorldID.GenericField7,
+                        GenericField8 = gameInfoByGameWorldID.GenericField8,
+                        WorldStatus = gameInfoByGameWorldID.WorldStatus,
                         JoinType = MediusJoinType.MediusJoinAsPlayer,
-                        GamePassword = gameMatchFound.GamePassword,
-                        GameHostType = gameMatchFound.GameHostType,
+                        GamePassword = gameInfoByGameWorldID.GamePassword,
+                        GameHostType = gameInfoByGameWorldID.GameHostType,
                         AddressList = new NetAddressList()
                         {
                             AddressList = new NetAddress[Constants.NET_ADDRESS_LIST_COUNT]
-                            {
-                                new NetAddress() { Address = dmeServer.IP.MapToIPv4().ToString(), Port = dmeServer.Port, AddressType = NetAddressType.NetAddressTypeExternal},
-                                new NetAddress() { AddressType = NetAddressType.NetAddressNone } 
-                            }
+                                {
+                                        new NetAddress() { Address = dmeServer.IP.MapToIPv4().ToString(), Port = dmeServer.Port, AddressType = NetAddressType.NetAddressTypeExternal},
+                                        new NetAddress() { AddressType = NetAddressType.NetAddressNone }
+                                }
                         },
-                        AppDataSize = gameMatchFound.AppDataSize,
-                        AppData = gameMatchFound.AppData
+                        AppDataSize = gameInfoByGameWorldID.AppDataSize,
+                        AppData = gameInfoByGameWorldID.AppData
+
                     });
                 }
+
+
             }
+
         }
 
         public Task<ONLINE_STATUS_TYPE> MediusChatStatusToOnlineStatus(MediusChatStatus status)


### PR DESCRIPTION
- Cleanup comments for some Matchmaking packets
- Add MediusMatchSetGameStateRequest/Response officially 
- Further improve MediusAssignedGameToJoin packet response
- *For sending a MediusNoResult in MediusAssignedGameToJoin  it still wants the full struct even if the rest of the fields are empty.*

Please NOTE the REQUESTDATA FIELD, and APPDATA field as they play a role in telling the game client the response to join properly.