### PR TITLE
Add ErrorCode to Aries

### DIFF
--- a/Servers/MultiSocks/Aries/AbstractAriesServer.cs
+++ b/Servers/MultiSocks/Aries/AbstractAriesServer.cs
@@ -141,7 +141,7 @@ namespace MultiSocks.Aries
             }
         }
 
-        public virtual void HandleMessage(string name, byte[] data, AriesClient client)
+        public virtual void HandleMessage(string name, uint errorCode, byte[] data, AriesClient client)
         {
             try
             {

--- a/Servers/MultiSocks/Aries/Messages/AbstractMessage.cs
+++ b/Servers/MultiSocks/Aries/Messages/AbstractMessage.cs
@@ -7,6 +7,7 @@ namespace MultiSocks.Aries.Messages
     {
         public abstract string _Name { get; }
         public string PlaintextData = string.Empty;
+        public uint ErrorCode { get; set; }
         public Dictionary<string, string?> OutputCache = new();
         private Dictionary<string, string?> InputCache = new();
 
@@ -131,8 +132,7 @@ namespace MultiSocks.Aries.Messages
             MemoryStream mem = new();
             BinaryWriter io = new(mem);
             io.Write(Encoding.ASCII.GetBytes(_Name));
-            if (!plaintext)
-                io.Write(0); //4 byte pad
+            io.Write(new byte[] { (byte)(ErrorCode >> 24), (byte)(ErrorCode >> 16), (byte)(ErrorCode >> 8), (byte)ErrorCode });
             io.Write(new byte[] { (byte)(size >> 24), (byte)(size >> 16), (byte)(size >> 8), (byte)size });
             io.Write(Encoding.ASCII.GetBytes(body));
 


### PR DESCRIPTION
After the first 4 bytes dictating the command being used the next 4 bytes are the error code which is usually 0 though for certain input parameters you may wish to populate this field. This PR fills in the basic errorcode reading and writing